### PR TITLE
Fix the version of `gradio_client` and maintain compatibility with `gradio==3.35.2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "scikit-learn==1.2.2",
     "sentencepiece==0.1.99",
     "einops==0.6.1", "einops-exts==0.0.4", "timm==0.6.13",
-    "gradio_client==0.2.7"
+    "gradio_client==0.2.9"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "bitsandbytes==0.40.1.post1",
     "scikit-learn==1.2.2",
     "sentencepiece==0.1.99",
-    "einops==0.6.1", "einops-exts==0.0.4", "timm==0.6.13"
+    "einops==0.6.1", "einops-exts==0.0.4", "timm==0.6.13",
+    "gradio_client==0.2.7"
 ]
 
 [project.urls]


### PR DESCRIPTION
Close #286

This pull request adds `gradio_client==0.2.7` to `pyproject.toml`. I used the version mentioned in the literature I found, but it should probably work with other versions as well.

I can easily make changes to the version or remove it if necessary. Please let me know if needed.

Thanks.