### PR TITLE
Use `self.get_model().get_vision_tower()` instead of `self.get_model().vision_tower` in `llava_arch.py`

### DIFF
--- a/llava/model/llava_arch.py
+++ b/llava/model/llava_arch.py
@@ -79,7 +79,7 @@ class LlavaMetaForCausalLM(ABC):
         return self.get_model().get_vision_tower()
 
     def encode_images(self, images):
-        image_features = self.get_model().get_vision_tower(images)
+        image_features = self.get_model().get_vision_tower()(images)
         image_features = self.get_model().mm_projector(image_features)
         return image_features
 

--- a/llava/model/llava_arch.py
+++ b/llava/model/llava_arch.py
@@ -79,7 +79,7 @@ class LlavaMetaForCausalLM(ABC):
         return self.get_model().get_vision_tower()
 
     def encode_images(self, images):
-        image_features = self.get_model().vision_tower(images)
+        image_features = self.get_model().get_vision_tower(images)
         image_features = self.get_model().mm_projector(image_features)
         return image_features
 


### PR DESCRIPTION
The error raise as follow:
```
  File "/mnt/petrelfs/liqingyun/LLaVA/llava/train/train_mem.py", line 13, in <module>
    train()
  File "/mnt/petrelfs/liqingyun/LLaVA/llava/train/train.py", line 925, in train
    trainer.train()
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/transformers/trainer.py", line 1644, in train
    return inner_training_loop(
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/transformers/trainer.py", line 1911, in _inner_training_loop
    tr_loss_step = self.training_step(model, inputs)
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/transformers/trainer.py", line 2657, in training_step
Traceback (most recent call last):
  File "/mnt/petrelfs/liqingyun/LLaVA/llava/train/train_mem.py", line 13, in <module>
    train()
  File "/mnt/petrelfs/liqingyun/LLaVA/llava/train/train.py", line 925, in train
    trainer.train()
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/transformers/trainer.py", line 1644, in train
    return inner_training_loop(
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/transformers/trainer.py", line 1911, in _inner_training_loop
    tr_loss_step = self.training_step(model, inputs)
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/transformers/trainer.py", line 2657, in training_step
    loss = self.compute_loss(model, inputs)
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/transformers/trainer.py", line 2689, in compute_loss
    outputs = model(**inputs)
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 748, in forward
    output = self._fsdp_wrapped_module(*args, **kwargs)
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/mnt/petrelfs/liqingyun/LLaVA/llava/model/language_model/llava_llama.py", line 82, in forward
    input_ids, attention_mask, past_key_values, inputs_embeds, labels = self.prepare_inputs_labels_for_multimodal(input_ids, attention_mask, past_key_values, labels, images)
  File "/mnt/petrelfs/liqingyun/LLaVA/llava/model/llava_arch.py", line 107, in prepare_inputs_labels_for_multimodal
    image_features = self.encode_images(images)
    loss = self.compute_loss(model, inputs)
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/transformers/trainer.py", line 2689, in compute_loss
  File "/mnt/petrelfs/liqingyun/LLaVA/llava/model/llava_arch.py", line 82, in encode_images
    image_features = self.get_model().vision_tower(images)
TypeError: 'list' object is not callable
    outputs = model(**inputs)
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
wandb: Waiting for W&B process to finish... (failed 1). Press Control-C to abort syncing.
    return forward_call(*args, **kwargs)
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 748, in forward
    output = self._fsdp_wrapped_module(*args, **kwargs)
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/llava/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/mnt/petrelfs/liqingyun/LLaVA/llava/model/language_model/llava_llama.py", line 82, in forward
    input_ids, attention_mask, past_key_values, inputs_embeds, labels = self.prepare_inputs_labels_for_multimodal(input_ids, attention_mask, past_key_values, labels, images)
  File "/mnt/petrelfs/liqingyun/LLaVA/llava/model/llava_arch.py", line 107, in prepare_inputs_labels_for_multimodal
    image_features = self.encode_images(images)
  File "/mnt/petrelfs/liqingyun/LLaVA/llava/model/llava_arch.py", line 82, in encode_images
    image_features = self.get_model().vision_tower(images)
TypeError: 'list' object is not callable
```


The attr is:
```
self.get_model().vision_tower
ipdb> [CLIPVisionTower(
  (vision_tower): CLIPVisionModel(
    (vision_model): CLIPVisionTransformer(
      (embeddings): CLIPVisionEmbeddings(
        (patch_embedding): Conv2d(3, 1024, kernel_size=(14, 14), stride=(14, 14), bias=False)
        (position_embedding): Embedding(257, 1024)
      )
      (pre_layrnorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
      (encoder): CLIPEncoder(
        (layers): ModuleList(
          (0-23): 24 x CLIPEncoderLayer(
            (self_attn): CLIPAttention(
              (k_proj): Linear(in_features=1024, out_features=1024, bias=True)
              (v_proj): Linear(in_features=1024, out_features=1024, bias=True)
              (q_proj): Linear(in_features=1024, out_features=1024, bias=True)
              (out_proj): Linear(in_features=1024, out_features=1024, bias=True)
            )
            (layer_norm1): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
            (mlp): CLIPMLP(
              (activation_fn): QuickGELUActivation()
              (fc1): Linear(in_features=1024, out_features=4096, bias=True)
              (fc2): Linear(in_features=4096, out_features=1024, bias=True)
            )
            (layer_norm2): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
          )
        )
      )
      (post_layernorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
    )
  )
)]
self.get_model().get_vision_tower()
ipdb> CLIPVisionTower(
  (vision_tower): CLIPVisionModel(
    (vision_model): CLIPVisionTransformer(
      (embeddings): CLIPVisionEmbeddings(
        (patch_embedding): Conv2d(3, 1024, kernel_size=(14, 14), stride=(14, 14), bias=False)
        (position_embedding): Embedding(257, 1024)
      )
      (pre_layrnorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
      (encoder): CLIPEncoder(
        (layers): ModuleList(
          (0-23): 24 x CLIPEncoderLayer(
            (self_attn): CLIPAttention(
              (k_proj): Linear(in_features=1024, out_features=1024, bias=True)
              (v_proj): Linear(in_features=1024, out_features=1024, bias=True)
              (q_proj): Linear(in_features=1024, out_features=1024, bias=True)
              (out_proj): Linear(in_features=1024, out_features=1024, bias=True)
            )
            (layer_norm1): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
            (mlp): CLIPMLP(
              (activation_fn): QuickGELUActivation()
              (fc1): Linear(in_features=1024, out_features=4096, bias=True)
              (fc2): Linear(in_features=4096, out_features=1024, bias=True)
            )
            (layer_norm2): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
          )
        )
      )
      (post_layernorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
    )
  )
)
```