### PR TITLE
Aligned llama2 pretraining configuration

### DIFF
--- a/scripts/pretrain.sh
+++ b/scripts/pretrain.sh
@@ -2,16 +2,13 @@
 
 # Uncomment and set the following variables correspondingly to run this script:
 
-########### Llama2 Configuration ###########
-# MODEL_VERSION=llama-2-7b-chat
-# PROMPT_VERSION=llama_2
-#############################################
-
-########### Vicuna Configuration ###########
 # MODEL_VERSION=vicuna-v1-3-7b
-# PROMPT_VERSION=v0_plain
-#############################################
+# MODEL_VERSION=llama-2-7b-chat
 
+########### DO NOT CHANGE ###########
+########### USE THIS FOR BOTH ###########
+PROMPT_VERSION=v0_plain
+########### DO NOT CHANGE ###########
 
 deepspeed llava/train/train_mem.py \
     --deepspeed /path/to/deepspeed.json \

--- a/scripts/pretrain.sh
+++ b/scripts/pretrain.sh
@@ -2,13 +2,16 @@
 
 # Uncomment and set the following variables correspondingly to run this script:
 
-# MODEL_VERSION=vicuna-v1-3-7b
+########### Llama2 Configuration ###########
 # MODEL_VERSION=llama-2-7b-chat
+# PROMPT_VERSION=llama_2
+#############################################
 
-########### DO NOT CHANGE ###########
-########### USE THIS FOR BOTH ###########
-PROMPT_VERSION=v0_plain
-########### DO NOT CHANGE ###########
+########### Vicuna Configuration ###########
+# MODEL_VERSION=vicuna-v1-3-7b
+# PROMPT_VERSION=v0_plain
+#############################################
+
 
 deepspeed llava/train/train_mem.py \
     --deepspeed /path/to/deepspeed.json \

--- a/scripts/zero2.json
+++ b/scripts/zero2.json
@@ -3,6 +3,8 @@
         "enabled": true
     },
     "train_micro_batch_size_per_gpu": "auto",
+    "train_batch_size": "auto",
+    "gradient_accumulation_steps": "auto",
     "zero_optimization": {
         "stage": 2,
         "overlap_comm": true,

--- a/scripts/zero3.json
+++ b/scripts/zero3.json
@@ -3,6 +3,8 @@
         "enabled": true
     },
     "train_micro_batch_size_per_gpu": "auto",
+    "train_batch_size": "auto",
+    "gradient_accumulation_steps": "auto",
     "zero_optimization": {
         "stage": 3,
         "overlap_comm": true,


### PR DESCRIPTION
LLaVA Version 1.0.0 specifies deepspeed==0.9.5, which encounters problems while running the pertaining script. These were solved by adding the "gradient_accumulation_steps" and "train_batch_size" arguments to the config file.
Regardless, running "pretraining.sh"  with "PROMPT_VERSION=v0_plain" also encounters problems in the data preprocessing, and works fine given "PROMPT_VERSION= llama_2"