### PR TITLE
Upgrade gradio to keep up with changes in gradio_client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-    "einops", "fastapi", "gradio==3.35.2", "markdown2[all]", "numpy",
+    "einops", "fastapi", "gradio==3.38.0", "markdown2[all]", "numpy",
     "requests", "sentencepiece", "tokenizers>=0.12.1",
     "torch", "torchvision", "uvicorn", "wandb",
     "shortuuid", "httpx==0.24.0",


### PR DESCRIPTION
Relates to #287

This fixes the following error that occurs to users who set up or update their environment with the `0.2.10` or later update of `gradio_client`.

```
Exception in ASGI application
    // - -
KeyError: 'dataset'
```

This is caused by a version mismatch between `gradio` and `gradio_client`. In #287 , we took an approach of fixing the version of `gradio_client`, but in this PR, we update the version of `gradio` to keep up with the changes in `gradio_client`.

The breaking changes from 3.35.2 to 3.38.0 update are only the removal of the `load_examples` API and the fixing of libraries.
https://github.com/gradio-app/gradio/blob/main/CHANGELOG.md

I built the environment from scratch on my machine (Arch Linux) and confirmed that the basic functionality works without any problems.
