### PR TITLE
feat: support pre-downloading clips for offline

### DIFF
--- a/llava/model/multimodal_encoder/builder.py
+++ b/llava/model/multimodal_encoder/builder.py
@@ -1,9 +1,11 @@
+import os
 from .clip_encoder import CLIPVisionTower
 
 
 def build_vision_tower(vision_tower_cfg, **kwargs):
     vision_tower = getattr(vision_tower_cfg, 'mm_vision_tower', getattr(vision_tower_cfg, 'vision_tower', None))
-    if vision_tower.startswith("openai") or vision_tower.startswith("laion"):
+    is_absolute_path_exists = os.path.exists(vision_tower)
+    if is_absolute_path_exists or vision_tower.startswith("openai") or vision_tower.startswith("laion"):
         return CLIPVisionTower(vision_tower, args=vision_tower_cfg, **kwargs)
 
     raise ValueError(f'Unknown vision tower: {vision_tower}')


### PR DESCRIPTION
Hello, I'm planning to deploy LLaVA in an offline environment without internet connectivity. I noticed that clips can only be downloaded from huggingface.co currently:
* https://github.com/haotian-liu/LLaVA/blob/main/llava/model/multimodal_encoder/builder.py#L6-L7

This PR adds support for importing clips from pre-downloaded local paths.

Thank you for your outstanding work :)

