### PR TITLE
Base license is Llama 2, not LLaMA

### DIFF
--- a/docs/MODEL_ZOO.md
+++ b/docs/MODEL_ZOO.md
@@ -4,7 +4,7 @@
 
 If you are interested in including any other details in Model Zoo, please open an issue :)
 
-The model weights below are *merged* weights. You do not need to apply delta. The usage of LLaVA checkpoints should comply with the base LLM's model license: [LLaMA](https://github.com/facebookresearch/llama/blob/main/MODEL_CARD.md).
+The model weights below are *merged* weights. You do not need to apply delta. The usage of LLaVA checkpoints should comply with the base LLM's model license: [Llama 2](https://github.com/facebookresearch/llama/blob/main/MODEL_CARD.md).
 
 ## LLaVA-v1.5
 


### PR DESCRIPTION
Llama 2 is available for commercial use, the original LLaMA is not.

Facebook changed their capitalization when they released Llama 2.