### PR TITLE
Support Apple Silicon devices for inference in model_worker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ You can launch as many workers as you want, and compare between different model 
 python -m llava.serve.model_worker --host 0.0.0.0 --controller http://localhost:10000 --port <different from 40000, say 40001> --worker http://localhost:<change accordingly, i.e. 40001> --model-path <ckpt2>
 ```
 
+I you are using an Apple device with an M1 or M2 chip, you can specify the mps device by using the --device flag: `--device mps`.
+
 #### Launch a model worker (Multiple GPUs, when GPU VRAM <= 24GB)
 
 If the VRAM of your GPU is less than 24GB (e.g., RTX 3090, RTX 4090, etc.), you may try running it with multiple GPUs. Our latest code base will automatically try to use multiple GPUs if you have more than one GPU. You can specify which GPUs to use with `CUDA_VISIBLE_DEVICES`. Below is an example of running with the first two GPUs.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can launch as many workers as you want, and compare between different model 
 python -m llava.serve.model_worker --host 0.0.0.0 --controller http://localhost:10000 --port <different from 40000, say 40001> --worker http://localhost:<change accordingly, i.e. 40001> --model-path <ckpt2>
 ```
 
-I you are using an Apple device with an M1 or M2 chip, you can specify the mps device by using the --device flag: `--device mps`.
+If you are using an Apple device with an M1 or M2 chip, you can specify the mps device by using the `--device` flag: `--device mps`.
 
 #### Launch a model worker (Multiple GPUs, when GPU VRAM <= 24GB)
 

--- a/llava/model/builder.py
+++ b/llava/model/builder.py
@@ -23,7 +23,7 @@ from llava.model import *
 from llava.constants import DEFAULT_IMAGE_PATCH_TOKEN, DEFAULT_IM_START_TOKEN, DEFAULT_IM_END_TOKEN
 
 
-def load_pretrained_model(model_path, model_base, model_name, load_8bit=False, load_4bit=False, device_map="auto"):
+def load_pretrained_model(model_path, model_base, model_name, load_8bit=False, load_4bit=False, device_map="auto", device="cuda"):
     kwargs = {"device_map": device_map}
 
     if load_8bit:
@@ -137,7 +137,7 @@ def load_pretrained_model(model_path, model_base, model_name, load_8bit=False, l
         vision_tower = model.get_vision_tower()
         if not vision_tower.is_loaded:
             vision_tower.load_model()
-        vision_tower.to(device='cuda', dtype=torch.float16)
+        vision_tower.to(device=device, dtype=torch.float16)
         image_processor = vision_tower.image_processor
 
     if hasattr(model.config, "max_sequence_length"):


### PR DESCRIPTION
This is a simple PR to allow this code to run on M1 and M2 devices.

Right now, it only affects model_worker.

In model worker you can pass the flag `--device` in order to select the pytorch device you want to use. This currently fails with GPU but it is working with MPS devices.

Usage example:
```
python -m llava.serve.model_worker --host 0.0.0.0 --controller http://localhost:10000 --port 40000 --worker http://localhost:40000 --model-path llava-v1.5-7b --device mps
```