### PR TITLE
set utf-8 for log file handler

### DIFF
--- a/llava/utils.py
+++ b/llava/utils.py
@@ -47,7 +47,7 @@ def build_logger(logger_name, logger_filename):
         os.makedirs(LOGDIR, exist_ok=True)
         filename = os.path.join(LOGDIR, logger_filename)
         handler = logging.handlers.TimedRotatingFileHandler(
-            filename, when='D', utc=True)
+            filename, when='D', utc=True, encoding='UTF-8')
         handler.setFormatter(formatter)
 
         for name, item in logging.root.manager.loggerDict.items():


### PR DESCRIPTION
On Windows using MS932 as encode, a log will cause an error. but the error report log will make another error and it repeat recursively.
The model worker can't work by the issue.
Setting UTF-8 for TimedRotatingFileHandler is the solution.