### PR TITLE
Fix Typos and Grammar and update variable name

### DIFF
--- a/llava/model/language_model/mpt/attention.py
+++ b/llava/model/language_model/mpt/attention.py
@@ -42,7 +42,7 @@ def scaled_multihead_dot_product_attention(query, key, value, n_heads, past_key_
     min_val = torch.finfo(q.dtype).min
     if key_padding_mask is not None:
         if attn_bias is not None:
-            warnings.warn('Propogating key_padding_mask to the attention module ' + 'and applying it within the attention module can cause ' + 'unneccessary computation/memory usage. Consider integrating ' + 'into attn_bias once and passing that to each attention ' + 'module instead.')
+            warnings.warn('Propagating key_padding_mask to the attention module ' + 'and applying it within the attention module can cause ' + 'unnecessary computation/memory usage. Consider integrating ' + 'into attn_bias once and passing that to each attention ' + 'module instead.')
         attn_weight = attn_weight.masked_fill(~key_padding_mask.view((b, 1, 1, s_k)), min_val)
     if is_causal and (not q.size(2) == 1):
         s = max(s_q, s_k)

--- a/llava/model/utils.py
+++ b/llava/model/utils.py
@@ -5,7 +5,7 @@ def auto_upgrade(config):
     cfg = AutoConfig.from_pretrained(config)
     if 'llava' in config and 'llava' not in cfg.model_type:
         assert cfg.model_type == 'llama'
-        print("You are using newer LLaVA code base, while the checkpoint of v0 is from older code base.")
+        print("You are using a newer LLaVA code base, while the checkpoint of v0 is from an older code base.")
         print("You must upgrade the checkpoint to the new code base (this can be done automatically).")
         confirm = input("Please confirm that you want to upgrade the checkpoint. [Y/N]")
         if confirm.lower() in ["y", "yes"]:

--- a/llava/train/train.py
+++ b/llava/train/train.py
@@ -368,8 +368,8 @@ def preprocess_llama_2(
         rounds = conversation.split(conv.sep2)
         cur_len = 1
         target[:cur_len] = IGNORE_INDEX
-        for i, rou in enumerate(rounds):
-            if rou == "":
+        for i, round in enumerate(rounds):
+            if round == "":
                 break
 
             parts = rou.split(sep)


### PR DESCRIPTION
### Description:
1. Fix typos in warning messages: Corrected instances of `unneccessary` to `unnecessary` and `Propogating` to `Propagating`.
2. updates the variable name `rou` to `round` for better clarity and alignment with common coding conventions. The change is applied in the loop where we iterate through 'rounds' in the preprocessing code.
3. Make a sentence grammatically correct for better readability.
   

### Changes Made:
- Corrected `unneccessary` to `unnecessary` in warning messages.
- Corrected `Propogating` to `Propagating` in warning messages.
- Replaced variable name `rou` with `round` in the loop.
- print("You are using `a` newer LLaVA code base, while the checkpoint of v0 is from `an` older code base.")
