### PR TITLE
[Enhancement] Simplify non-training installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pip install -e .
 
 3. Install additional packages for training cases
 ```
-pip install ninja
+pip install ninja deepspeed==0.9.5
 pip install flash-attn --no-build-isolation
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,18 +13,29 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-    "einops", "fastapi", "gradio==3.35.2", "markdown2[all]", "numpy",
-    "requests", "sentencepiece", "tokenizers>=0.12.1",
-    "torch==2.0.1", "torchvision==0.15.2", "uvicorn", "wandb",
-    "shortuuid", "httpx==0.24.0",
-    "deepspeed==0.9.5",
+    "einops",
+    "fastapi",
+    "gradio==3.35.2",
+    "markdown2[all]",
+    "numpy",
+    "requests",
+    "sentencepiece",
+    "tokenizers>=0.12.1",
+    "torch==2.0.1",
+    "torchvision==0.15.2",
+    "uvicorn",
+    "wandb",
+    "shortuuid",
+    "httpx==0.24.0",
     "peft==0.4.0",
     "transformers==4.31.0",
     "accelerate==0.21.0",
     "bitsandbytes==0.41.0",
     "scikit-learn==1.2.2",
     "sentencepiece==0.1.99",
-    "einops==0.6.1", "einops-exts==0.0.4", "timm==0.6.13",
+    "einops==0.6.1",
+    "einops-exts==0.0.4"
+    "timm==0.6.13",
     "gradio_client==0.2.9"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "scikit-learn==1.2.2",
     "sentencepiece==0.1.99",
     "einops==0.6.1",
-    "einops-exts==0.0.4"
+    "einops-exts==0.0.4",
     "timm==0.6.13",
     "gradio_client==0.2.9"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "shortuuid",
     "httpx==0.24.0",
     "peft==0.4.0",
-    "transformers==4.31.0",
+    "transformers>=4.31.0",
     "accelerate==0.21.0",
     "bitsandbytes==0.41.0",
     "scikit-learn==1.2.2",


### PR DESCRIPTION
This removes the `deepspeed` install dependency and moves it to additional installation steps similar to flash attention and nina so that anyone needing just the inference steps can ignore the added dependencies needed by deepspeed.