### PR TITLE
allow inputs_embeds to be passed to forward call

### DIFF
--- a/llava/model/language_model/llava_llama.py
+++ b/llava/model/language_model/llava_llama.py
@@ -72,7 +72,9 @@ class LlavaLlamaForCausalLM(LlamaForCausalLM, LlavaMetaForCausalLM):
         )
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        input_ids, attention_mask, past_key_values, inputs_embeds, labels = self.prepare_inputs_labels_for_multimodal(input_ids, attention_mask, past_key_values, labels, images)
+        input_ids, attention_mask, past_key_values, inputs_embeds_prepared, labels = self.prepare_inputs_labels_for_multimodal(input_ids, attention_mask, past_key_values, labels, images)
+        if inputs_embeds is None:
+            inputs_embeds = inputs_embeds_prepared
 
         # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
         outputs = self.model(


### PR DESCRIPTION
This two line change doesn't clobber inputs_embeds in the (probably rare) case where someone passes it to the forward call. 

---- 8< ---

In the forward call of the model, the inputs_embeds was being set by the internal helper call
`self.prepare_inputs_labels_for_multimodal()`.
However, inputs_embeds is also a valid parameter and
should probably not be overwritten in all cases.

This workaround only assigns this value internally when the value provided still has the default
value of None. Otherwise, the value passed to the call is honored.

Was tested on code calling the model via
`model(inputs_embeds=embeds)` and seemed
to work as expected.