### PR TITLE
use images instead of image to match model.forward kwarg

### DIFF
--- a/llava/train/train.py
+++ b/llava/train/train.py
@@ -654,7 +654,7 @@ class LazySupervisedDataset(Dataset):
         length_list = []
         for sample in self.list_data_dict:
             cur_len = sum(len(conv['value'].split()) for conv in sample['conversations'])
-            cur_len = cur_len if 'image' in sample else -cur_len
+            cur_len = cur_len if 'images' in sample else -cur_len
             length_list.append(cur_len)
         return length_list
 
@@ -700,11 +700,11 @@ class LazySupervisedDataset(Dataset):
 
         # image exist in the data
         if 'image' in self.list_data_dict[i]:
-            data_dict['image'] = image
+            data_dict['images'] = image
         elif self.data_args.is_multimodal:
             # image does not exist in the data, but the model is multimodal
             crop_size = self.data_args.image_processor.crop_size
-            data_dict['image'] = torch.zeros(3, crop_size['height'], crop_size['width'])
+            data_dict['images'] = torch.zeros(3, crop_size['height'], crop_size['width'])
         return data_dict
 
 
@@ -732,8 +732,8 @@ class DataCollatorForSupervisedDataset(object):
             attention_mask=input_ids.ne(self.tokenizer.pad_token_id),
         )
 
-        if 'image' in instances[0]:
-            images = [instance['image'] for instance in instances]
+        if 'images' in instances[0]:
+            images = [instance['images'] for instance in instances]
             if all(x is not None and x.shape == images[0].shape for x in images):
                 batch['images'] = torch.stack(images)
             else:


### PR DESCRIPTION
the [model's forward method expects](https://github.com/haotian-liu/LLaVA/blob/main/llava/model/language_model/llava_llama.py#L66) `images` as a keyword arg. This is getting set as `image` currently and gets removed by [HF's RemoveColumnsCollator](https://github.com/huggingface/transformers/blob/main/src/transformers/trainer.py#L724-L730) since `image` isn't a valid kwarg to pass to the `model.forward(...)` 

RemoveColumnsCollator wraps the DataCollatorForSupervisedDataset, so even though DataCollatorForSupervisedDataset outputs an `images` feature, `image` gets stripped before it ever makes it to the collator`
