### PR TITLE
Assign finish_tstamp to finish

### DIFF
--- a/llava/serve/gradio_web_server.py
+++ b/llava/serve/gradio_web_server.py
@@ -271,7 +271,7 @@ def http_bot(state, model_selector, temperature, top_p, max_new_tokens, request:
             "type": "chat",
             "model": model_name,
             "start": round(start_tstamp, 4),
-            "finish": round(start_tstamp, 4),
+            "finish": round(finish_tstamp, 4),
             "state": state.dict(),
             "images": all_image_hash,
             "ip": request.client.host,


### PR DESCRIPTION
There was typo of assigning the `start_tstamp` to the `finish` value in the log file.