### PR TITLE
fix: Prevent unexpected device change caused by torch.split function

### DIFF
--- a/llava/model/llava_arch.py
+++ b/llava/model/llava_arch.py
@@ -110,7 +110,7 @@ class LlavaMetaForCausalLM(ABC):
             image_features = self.encode_images(concat_images)
             split_sizes = [image.shape[0] for image in images]
             image_features = torch.split(image_features, split_sizes, dim=0)
-            image_features = [x.flatten(0, 1) for x in image_features]
+            image_features = [x.flatten(0, 1).to(concat_images.device) for x in image_features]
         else:
             image_features = self.encode_images(images)
 


### PR DESCRIPTION

In parallel GPU mode, the `torch.split` function can sometimes produce a result tensor on a device different from the input tensor. This can lead to errors such as:

```
Error generating stream: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cuda:3! (when checking argument for argument tensors in method wrapper_CUDA_cat)
```

To resolve this issue, this PR proposes assigning the same device as the input tensor to prevent such occurrences.