### PR TITLE
Add warnings for conflicting `freeze_backbone` and `enable_lora` settings

### DIFF
--- a/llava/train/train.py
+++ b/llava/train/train.py
@@ -760,6 +760,11 @@ def train():
     parser = transformers.HfArgumentParser(
         (ModelArguments, DataArguments, TrainingArguments))
     model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+    if training_args.lora_enable and training_args.freeze_backbone:
+        raise Warning("LoRA is enabled but the backbone is wanted to be frozen. This is\
+                       not recommended as LoRA will fine-tune the backbone. If you want\
+                       to freeze the backbone, please disable LoRA.")
+    
     local_rank = training_args.local_rank
     compute_dtype = (torch.float16 if training_args.fp16 else (torch.bfloat16 if training_args.bf16 else torch.float32))
 

--- a/llava/train/train.py
+++ b/llava/train/train.py
@@ -761,9 +761,15 @@ def train():
         (ModelArguments, DataArguments, TrainingArguments))
     model_args, data_args, training_args = parser.parse_args_into_dataclasses()
     if training_args.lora_enable and training_args.freeze_backbone:
-        raise Warning("LoRA is enabled but the backbone is wanted to be frozen. This is\
+        print("Warning: LoRA is enabled but the backbone is wanted to be frozen. This is\
                        not recommended as LoRA will fine-tune the backbone. If you want\
                        to freeze the backbone, please disable LoRA.")
+    if training_args.lora_enable and (not training_args.freeze_backbone):
+        print("Warning: LoRA is enabled and the backbone weights are not frozen. This\
+                        will lead to both the LoRA and the backbone weights being\
+                        fine-tuned. If you want to fine-tune only the LoRA weights,\
+                        please enable the `freeze_backbone` flag. If you want to do full\
+                        fine-tuning, please disable LoRA.")
     
     local_rank = training_args.local_rank
     compute_dtype = (torch.float16 if training_args.fp16 else (torch.bfloat16 if training_args.bf16 else torch.float32))


### PR DESCRIPTION
I found this confusing: When both `freeze_backbone` and `enable_lora` are set to `True`, the LLM will still be fine-tuned by LoRA. This behavior seems to counter the intended purpose of the `freeze_backbone` flag. While this might be obvious to some, I believe adding a warning can help clarify this for all users.

Similarly, when `enable_lora` is set to `True` and `freeze_backbone` is set to `False`, the parameters of both LoRA and the full model will be fine-tuned, which is usually not required. I also added a warning in that case.

Please correct me if my understanding of these parameters is incorrect.
