### PR TITLE
Made `gradio` an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cd LLaVA
 conda create -n llava python=3.10 -y
 conda activate llava
 pip install --upgrade pip  # enable PEP 660 support
-pip install -e .
+pip install -e .[gradio] # Install with optional gradio dependencies
 ```
 
 3. Install additional packages for training cases
@@ -172,11 +172,19 @@ flowchart BT
 ```
 
 #### Launch a controller
+
 ```Shell
 python -m llava.serve.controller --host 0.0.0.0 --port 10000
 ```
 
 #### Launch a gradio web server.
+
+First make sure you have installed the package with gradio as mentioned above:
+```Shell
+pip install -e .[gradio]
+```
+
+Launch the server:
 ```Shell
 python -m llava.serve.gradio_web_server --controller http://localhost:10000 --model-list-mode reload
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ dependencies = [
     "transformers==4.31.0", "tokenizers>=0.12.1,<0.14", "sentencepiece==0.1.99", "shortuuid",
     "accelerate==0.21.0", "peft==0.4.0", "bitsandbytes==0.41.0",
     "pydantic<2,>=1", "markdown2[all]", "numpy", "scikit-learn==1.2.2",
-    "gradio==3.35.2", "gradio_client==0.2.9",
     "requests", "httpx==0.24.0", "uvicorn", "fastapi",
     "einops==0.6.1", "einops-exts==0.0.4", "timm==0.6.13",
 ]
 
 [project.optional-dependencies]
 train = ["deepspeed==0.9.5", "ninja", "wandb"]
+gradio = ["gradio==3.35.2", "gradio_client==0.2.9"]
 
 [project.urls]
 "Homepage" = "https://llava-vl.github.io"


### PR DESCRIPTION
Made gradio optional as it is not strictly needed to run the model.

*Changes*:
- Added 'gradio' optional dependency in the pyproject.toml file
- Update README.md to add instructions to install gradio