### PR TITLE
🩹 make ``load_pretrained_model`` accept kwargs

### DIFF
--- a/llava/model/builder.py
+++ b/llava/model/builder.py
@@ -23,8 +23,8 @@ from llava.model import *
 from llava.constants import DEFAULT_IMAGE_PATCH_TOKEN, DEFAULT_IM_START_TOKEN, DEFAULT_IM_END_TOKEN
 
 
-def load_pretrained_model(model_path, model_base, model_name, load_8bit=False, load_4bit=False, device_map="auto", device="cuda"):
-    kwargs = {"device_map": device_map}
+def load_pretrained_model(model_path, model_base, model_name, load_8bit=False, load_4bit=False, device_map="auto", device="cuda", **kwargs):
+    kwargs = {"device_map": device_map, **kwargs}
 
     if device != "cuda":
         kwargs['device_map'] = {"": device}


### PR DESCRIPTION
This simple PR makes it possible to e.g. pass a ``cache_dir`` argument in the ``load_pretrained_model`` function, which can be really useful if the default location does not have enough storage.