### PR TITLE
Timmvit  and laion data

### DIFF
--- a/llava/model/llava_arch.py
+++ b/llava/model/llava_arch.py
@@ -44,6 +44,7 @@ class LlavaMetaModel:
         mm_vision_select_layer = model_args.mm_vision_select_layer
         mm_vision_select_feature = model_args.mm_vision_select_feature
         pretrain_mm_mlp_adapter = model_args.pretrain_mm_mlp_adapter
+        use_timm_vision_tower = model_args.use_timm_vision_tower
 
         self.config.mm_vision_tower = vision_tower
 
@@ -66,6 +67,7 @@ class LlavaMetaModel:
         self.config.mm_hidden_size = vision_tower.hidden_size
         self.config.mm_vision_select_layer = mm_vision_select_layer
         self.config.mm_vision_select_feature = mm_vision_select_feature
+        self.config.use_timm_vision_tower = use_timm_vision_tower
 
         if getattr(self, 'mm_projector', None) is None:
             self.mm_projector = build_vision_projector(self.config)

--- a/llava/model/multimodal_encoder/builder.py
+++ b/llava/model/multimodal_encoder/builder.py
@@ -1,10 +1,12 @@
 import os
 from .clip_encoder import CLIPVisionTower
-
+from .timm_clip_encoder import TIMMVisionTower
 
 def build_vision_tower(vision_tower_cfg, **kwargs):
     vision_tower = getattr(vision_tower_cfg, 'mm_vision_tower', getattr(vision_tower_cfg, 'vision_tower', None))
     is_absolute_path_exists = os.path.exists(vision_tower)
+    if vision_tower_cfg.use_timm_vision_tower:
+        return TIMMVisionTower(vision_tower, args=vision_tower_cfg, **kwargs)
     if is_absolute_path_exists or vision_tower.startswith("openai") or vision_tower.startswith("laion"):
         return CLIPVisionTower(vision_tower, args=vision_tower_cfg, **kwargs)
 

--- a/llava/model/multimodal_encoder/timm_clip_encoder.py
+++ b/llava/model/multimodal_encoder/timm_clip_encoder.py
@@ -1,0 +1,88 @@
+import torch
+import torch.nn as nn
+import timm
+
+class TIMMImageProcessor:
+    def __init__(self, vision_tower):
+        self.image_mean = list(vision_tower.default_cfg["mean"]) #  [0.48145466, 0.4578275, 0.40821073]
+        crop_size = vision_tower.default_cfg["input_size"]
+        self.crop_size = {
+            'height': crop_size[1],
+            'width': crop_size[2]
+        }
+        # get model specific transforms (normalization, resize)
+        data_config = timm.data.resolve_model_data_config(vision_tower)
+        self.transforms = timm.data.create_transform(**data_config, is_training=False)
+
+    def preprocess(self, img, return_tensors='pt'):
+        if img.mode != 'RGB':
+            img = img.convert('RGB')
+        transformed_img = self.transforms(img)
+        return {'pixel_values': [transformed_img]}
+
+
+class TIMMVisionTower(nn.Module):
+    def __init__(self, vision_tower, args, delay_load=False):
+        super().__init__()
+
+        self.is_loaded = False
+        self.vision_tower_name = vision_tower
+        self.load_model()
+
+    def load_model(self):
+        import os
+        files = os.listdir(self.vision_tower_name)
+        for file_name in files:
+            if file_name.endswith('.bin'):
+                bin_file = os.path.join(self.vision_tower_name, file_name)
+        assert os.path.exists(bin_file)
+        self.vision_tower = timm.create_model(
+            self.vision_tower_name,
+            pretrained=True,
+            # features_only=True,
+            pretrained_cfg_overlay=dict(file=bin_file),
+            num_classes=0,  # remove classifier nn.Linear
+            global_pool=''
+        )
+        self.vision_tower = self.vision_tower.eval()
+        print("loaded!")
+
+        self.image_processor = TIMMImageProcessor(self.vision_tower)
+        self.is_loaded = True
+
+
+    # @torch.no_grad()
+    def forward(self, images):
+        if type(images) is list:
+            image_features = []
+            for image in images:
+                image_feature = self.vision_tower(image.to(device=self.device, dtype=self.dtype).unsqueeze(0)).to(image.dtype)[:, 1:, :] # remove CLS token
+                image_features.append(image_feature)
+        else:
+            image_features = self.vision_tower(images.to(device=self.device, dtype=self.dtype)).to(images[0].dtype)[:, 1:, :] # remove CLS token
+
+        return image_features
+
+    @property
+    def dummy_feature(self):
+        return torch.zeros(1, self.hidden_size, device=self.device, dtype=self.dtype)
+
+    @property
+    def dtype(self):
+        return self.vision_tower._parameters[list(self.vision_tower._parameters.keys())[0]].dtype
+
+    @property
+    def device(self):
+        return self.vision_tower._parameters[list(self.vision_tower._parameters.keys())[0]].device
+
+    # @property
+    # def config(self):
+    #     if self.is_loaded:
+    #         return self.vision_tower.config
+    #     else:
+    #         return self.cfg_only
+
+    @property
+    def hidden_size(self):
+        return self.vision_tower.embed_dim
+

--- a/llava/train/train.py
+++ b/llava/train/train.py
@@ -35,7 +35,7 @@ from llava.model import *
 from llava.mm_utils import tokenizer_image_token
 
 from PIL import Image
-
+import random
 
 local_rank = None
 
@@ -71,7 +71,7 @@ class DataArguments:
     image_aspect_ratio: str = 'square'
     ##### use laion_data
     laion_path: str = field(default=None,
-                           metadata={"help": "path for laion400m"})
+                           metadata={"help": "path for laion"})
     laion_amount: int = 0
 
 
@@ -631,7 +631,7 @@ def preprocess(
 import webdataset as wds
 import glob
 import io
-def create_laion_400m_dataset(
+def create_laion_dataset(
     data_dir,
     cache_path=None,
 ):
@@ -679,7 +679,7 @@ class LazySupervisedDataset(Dataset):
             'Create a compact narrative representing the image presented.'
         ]
         self.laion_iter = None
-        ###### add laion_400m data
+        ###### add laion data
         if data_args.laion_path is not None:
             self.laion_iter = create_laion_dataset(data_args.laion_path)
 
@@ -981,7 +981,7 @@ def train():
             model_args=model_args,
             fsdp=training_args.fsdp
         )
-        
+
         vision_tower = model.get_vision_tower()
         vision_tower.to(dtype=torch.bfloat16 if training_args.bf16 else torch.float16, device=training_args.device)
 


### PR DESCRIPTION
1. In llava/model/multimodal_encoder/timm_clip_encoder.py, add the vit usage in timm , such as siglip([https://huggingface.co/timm/ViT-SO400M-14-SigLIP-384]) and openclip,need to set **use_timm_vision_tower** as True

2. add laion data (llava/train/train.py), need to refer **laion_path**: the path of laion data and **laion_amount**: the data amount of laion to use

A simple startup for pretrain: (need to download the timm vit to the path of vision_tower and download laion data)

deepspeed llava/train/train_mem.py \
    --deepspeed ./scripts/zero2.json \
    --model_name_or_path lmsys/vicuna-13b-v1.5 \
    --version plain \
    --data_path ./playground/data/LLaVA-Pretrain/blip_laion_cc_sbu_558k.json \
    --image_folder ./playground/data/LLaVA-Pretrain/images \
    --vision_tower path-to-timm-vit \
    --mm_projector_type mlp2x_gelu \
    --tune_mm_mlp_adapter True \
    --mm_vision_select_layer -2 \
    --mm_use_im_start_end False \
    --mm_use_im_patch_token False \
    --bf16 True \
    --output_dir ./checkpoints/llava-v1.5-13b-pretrain \
    --num_train_epochs 1 \
    --per_device_train_batch_size 32 \
    --per_device_eval_batch_size 4 \
    --gradient_accumulation_steps 1 \
    --evaluation_strategy "no" \
    --save_strategy "steps" \
    --save_steps 24000 \
    --save_total_limit 1 \
    --learning_rate 1e-3 \
    --weight_decay 0. \
    --warmup_ratio 0.03 \
    --lr_scheduler_type "cosine" \
    --logging_steps 1 \
    --tf32 True \
    --model_max_length 2048 \
    --gradient_checkpointing True \
    --dataloader_num_workers 4 \
    --lazy_preprocess True \
    --report_to wandb \
    --use_timm_vision_tower True \
    --laion_path  path-to-laion-data \
    --laion_amount 1000000

