### PR TITLE
resize token embeddings only if added tokens in load_pretrained_model()

### DIFF
--- a/llava/model/builder.py
+++ b/llava/model/builder.py
@@ -131,11 +131,15 @@ def load_pretrained_model(model_path, model_base, model_name, load_8bit=False, l
     if 'llava' in model_name.lower():
         mm_use_im_start_end = getattr(model.config, "mm_use_im_start_end", False)
         mm_use_im_patch_token = getattr(model.config, "mm_use_im_patch_token", True)
+        added_tokens = False
         if mm_use_im_patch_token:
             tokenizer.add_tokens([DEFAULT_IMAGE_PATCH_TOKEN], special_tokens=True)
+            add_tokens = True
         if mm_use_im_start_end:
             tokenizer.add_tokens([DEFAULT_IM_START_TOKEN, DEFAULT_IM_END_TOKEN], special_tokens=True)
-        model.resize_token_embeddings(len(tokenizer))
+            added_tokens = True
+        if added_tokens:
+            model.resize_token_embeddings(len(tokenizer))
 
         vision_tower = model.get_vision_tower()
         if not vision_tower.is_loaded:


### PR DESCRIPTION
In the `load_pretrained_model()` function, we should resize token embeddings only when new tokens are added to the tokenizer.
This PR prevents unnecessary changes to the model's vocab_size on my end.