### PR TITLE
Prevent failing if tensors are of different shape

### DIFF
--- a/llava/mm_utils.py
+++ b/llava/mm_utils.py
@@ -231,7 +231,8 @@ class KeywordsStoppingCriteria(StoppingCriteria):
         offset = min(output_ids.shape[1] - self.start_len, self.max_keyword_len)
         self.keyword_ids = [keyword_id.to(output_ids.device) for keyword_id in self.keyword_ids]
         for keyword_id in self.keyword_ids:
-            if (output_ids[0, -keyword_id.shape[0]:] == keyword_id).all():
+            truncated_output_ids = output_ids[0, -keyword_id.shape[0]:]
+            if torch.equal(truncated_output_ids, keyword_id):
                 return True
         outputs = self.tokenizer.batch_decode(output_ids[:, -offset:], skip_special_tokens=True)[0]
         for keyword in self.keywords:


### PR DESCRIPTION
Hi there,

I was receiving the following traceback[0] when attempting to use LLaVA 1.6-32b. Investigation revealed that if the output sequence had fewer tokens than the keyword sequence, the check would fail. I've replaced the check with `torch.equal`, which can gracefully handle size mismatches by returning false in the event that the two compared tensors are of different length. After applying this patch, it now works for me.

Thanks,

Tim

[0] 
```Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/workspace/miniconda/envs/llava/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/workspace/LLaVA/llava/model/language_model/llava_llama.py", line 137, in generate
    return super().generate(
  File "/workspace/miniconda/envs/llava/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/workspace/miniconda/envs/llava/lib/python3.10/site-packages/transformers/generation/utils.py", line 1718, in generate
    return self.greedy_search(
  File "/workspace/miniconda/envs/llava/lib/python3.10/site-packages/transformers/generation/utils.py", line 2640, in greedy_search
    if stopping_criteria(input_ids, scores):
  File "/workspace/miniconda/envs/llava/lib/python3.10/site-packages/transformers/generation/stopping_criteria.py", line 132, in __call__
    return any(criteria(input_ids, scores) for criteria in self)
  File "/workspace/miniconda/envs/llava/lib/python3.10/site-packages/transformers/generation/stopping_criteria.py", line 132, in <genexpr>
    return any(criteria(input_ids, scores) for criteria in self)
  File "/workspace/LLaVA/llava/mm_utils.py", line 245, in __call__
    outputs.append(self.call_for_batch(output_ids[i].unsqueeze(0), scores))
  File "/workspace/LLaVA/llava/mm_utils.py", line 234, in call_for_batch
    if (output_ids[0, -keyword_id.shape[0]:] == keyword_id).all():
RuntimeError: The size of tensor a (2) must match the size of tensor b (3) at non-singleton dimension 0
```