### PR TITLE
improve process for last megabatch

### DIFF
--- a/llava/train/llava_trainer.py
+++ b/llava/train/llava_trainer.py
@@ -79,8 +79,11 @@ def get_modality_length_grouped_indices(lengths, batch_size, world_size, generat
     megabatch_indices = torch.randperm(len(megabatches), generator=generator)
     megabatches = [megabatches[i] for i in megabatch_indices]
 
-    if len(additional_batch) > 0:
-        megabatches.append(sorted(additional_batch))
+    if len(additional_batch) > megabatch_size:
+        megabatches.append(additional_batch[:megabatch_size])
+        megabatches.append(additional_batch[megabatch_size:])
+    elif len(additional_batch) > 0:
+        megabatches.append(additional_batch)
 
     return [i for megabatch in megabatches for i in megabatch]
 


### PR DESCRIPTION
improve process for last megabatch due to:
1. `sorted` seems to be no need
2. last megabatch may be larger than `megabatch_size`