### PR TITLE
Update the link for the SEED-Bench benchmark instructions

### DIFF
--- a/docs/Evaluation.md
+++ b/docs/Evaluation.md
@@ -117,7 +117,7 @@ CUDA_VISIBLE_DEVICES=0 bash scripts/v1_5/eval/mmbench_cn.sh
 
 ### SEED-Bench
 
-1. Following the official [instructions](https://github.com/AILab-CVC/SEED-Bench/blob/main/DATASET.md) to download the images and the videos. Put images under `./playground/data/eval/seed_bench/SEED-Bench-image`.
+1. Follow the official instructions [Data Preparation for SEED-Bench-1](https://github.com/AILab-CVC/SEED-Bench/blob/main/DATASET.md#data-preparation-for-seed-bench-1) to download the images and the videos. Put images under `./playground/data/eval/seed_bench/SEED-Bench-image`.
 2. Extract the video frame in the middle from the downloaded videos, and put them under `./playground/data/eval/seed_bench/SEED-Bench-video-image`. We provide our script `extract_video_frames.py` modified from the official one.
 3. Multiple-GPU inference and evaluate.
 ```Shell


### PR DESCRIPTION
The DATASET.md file of Seed-Bench now contains instructions for both versions of Seed-Bench (v1 and v2). In the LLaVA-1.5 paper, you reference the paper presenting Seed-Bench-1. So, this link as it is now might be confusing, and I'd like to add an anchor pointing to the section about data preparation for Seed-Bench-1.