### PR TITLE
Refactor run_llava to avoid duplicated model loading if multiple evaluation is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,23 @@ args = type('Args', (), {
 
 eval_model(args)
 ```
+
+You can use `get_model_and_processor` combined with `run_for_outputs` to avoid duplicated loading model
+
+```
+from types import SimpleNamespace
+
+model_path = "liuhaotian/llava-v1.5-7b"
+prompt = "What are the things I should be cautious about when I visit here?"
+image_file = "https://llava-vl.github.io/static/images/view.jpg"
+
+model, image_processor, tokenizer, p_conv_mode = get_model_and_processor(model_path)
+cfig = {"model": model, "image_processor": image_processor, "tokenizer": tokenizer, "p_conv_mode": p_conv_mode}
+
+args = SimpleNamespace(query=prompt, image_file=img_path, 
+                        sep=",", temperature=0, top_p=None, num_beams=1, max_new_tokens=512)
+run_for_outputs(cfig, args)
+```
 </details>
 
 ## LLaVA Weights

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ image_file = "https://llava-vl.github.io/static/images/view.jpg"
 model, image_processor, tokenizer, p_conv_mode = get_model_and_processor(model_path)
 cfig = {"model": model, "image_processor": image_processor, "tokenizer": tokenizer, "p_conv_mode": p_conv_mode}
 
-args = SimpleNamespace(query=prompt, image_file=img_path, 
+args = SimpleNamespace(query=prompt, image_file=image_file, 
                         sep=",", temperature=0, top_p=None, num_beams=1, max_new_tokens=512)
 run_for_outputs(cfig, args)
 ```

--- a/llava/eval/run_llava.py
+++ b/llava/eval/run_llava.py
@@ -47,7 +47,7 @@ def load_images(image_files):
     return out
 
 def run_for_outputs(cfig, args):
-    model, image_processor, tokenizer, p_conv_mode = cfig.model, cfig.image_processor, cfig.tokenizer, cfig.p_conv_mode
+    model, image_processor, tokenizer, p_conv_mode = cfig["model"], cfig["image_processor"], cfig["tokenizer"], cfig["p_conv_mode"]
     
     qs = args.query
     image_token_se = DEFAULT_IM_START_TOKEN + DEFAULT_IMAGE_TOKEN + DEFAULT_IM_END_TOKEN
@@ -99,7 +99,7 @@ def run_for_outputs(cfig, args):
     print(outputs)
     return outputs # return for further processing
 
-def get_model_and_processor(model_path, model_base, p_conv_mode):
+def get_model_and_processor(model_path, model_base=None, p_conv_mode=None):
     # Model
     disable_torch_init()
     

--- a/llava/model/__init__.py
+++ b/llava/model/__init__.py
@@ -2,5 +2,6 @@ try:
     from .language_model.llava_llama import LlavaLlamaForCausalLM, LlavaConfig
     from .language_model.llava_mpt import LlavaMptForCausalLM, LlavaMptConfig
     from .language_model.llava_mistral import LlavaMistralForCausalLM, LlavaMistralConfig
-except:
+except Exception as e:
+    print(f"Fail to import files: {e}")
     pass


### PR DESCRIPTION

1. Refactor function `eval_model` into `get_model_and_processor` and `run_for_outputs`.  When multiple evaluation is required, call `get_model_and_processor` to get model, image processor, and tokenizer to load model first,  then  call `run_for_outputs` as many times as required to evaluate images.
2. Return output from function `eval_model` for further usage.

