### PR TITLE
enabling mistral training by adding mistral template 

### DIFF
--- a/llava/conversation.py
+++ b/llava/conversation.py
@@ -357,7 +357,15 @@ conv_mistral_instruct = Conversation(
     sep="",
     sep2="</s>",
 )
-
+conv_biomistral = Conversation(
+    system="""<s> [INST] system Answer the questions.<s>""",
+    roles=("[INST]user\n", "[/INST]assistant\n"),
+    version="mistral",
+    messages=(),
+    offset=0,
+    sep_style=SeparatorStyle.biomistral,
+    sep="<s>",
+)
 conv_chatml_direct = Conversation(
     system="""<|im_start|>system
 Answer the questions.""",
@@ -379,7 +387,7 @@ conv_templates = {
     "mistral_instruct": conv_mistral_instruct,
     "chatml_direct": conv_chatml_direct,
     "mistral_direct": conv_chatml_direct,
-
+    "mistral_bio":conv_biomistral,
     "plain": conv_llava_plain,
     "v0_plain": conv_llava_plain,
     "llava_v0": conv_llava_v0,


### PR DESCRIPTION
## Pull Request Description

### Changes Made
Added `conv_biomistral` template for mistral training in the ./llava/conversation.py

### Details
- Updated the file to include the `conv_biomistral` template.
- This template follows the mistral  format and includes the necessary system and user/assistant roles.

### Purpose
This pull request aims to provide a template (`conv_biomistral`) suitable for mistral training. It follows the specified format and should enhance the capabilities of the training process.


### Checklist
- [ ] I have tested the changes locally.
- [ ] The code follows the project's coding standards.
