### PR TITLE
fix: remove redundant code in cli.py

### DIFF
--- a/llava/serve/cli.py
+++ b/llava/serve/cli.py
@@ -81,11 +81,9 @@ def main(args):
                 inp = DEFAULT_IM_START_TOKEN + DEFAULT_IMAGE_TOKEN + DEFAULT_IM_END_TOKEN + '\n' + inp
             else:
                 inp = DEFAULT_IMAGE_TOKEN + '\n' + inp
-            conv.append_message(conv.roles[0], inp)
             image = None
-        else:
-            # later messages
-            conv.append_message(conv.roles[0], inp)
+        
+        conv.append_message(conv.roles[0], inp)
         conv.append_message(conv.roles[1], None)
         prompt = conv.get_prompt()
 


### PR DESCRIPTION
the following statement gets executed irrespective of the if else statement. So, placing it out of the conditionals statements and removing the else part is considered as a better practice
`conv.append_message(conv.roles[0], inp)`
