### PR TITLE
bumped torch and torchvision version numbers

### DIFF
--- a/docs/macOS.md
+++ b/docs/macOS.md
@@ -16,7 +16,7 @@ conda create -n llava python=3.10 -y
 conda activate llava
 python -mpip install --upgrade pip  # enable PEP 660 support
 pip install -e .
-pip install torch==2.1.0 torchvision==0.16.0
+pip install torch==2.1.2 torchvision==0.16.2
 pip uninstall bitsandbytes
 ```
 


### PR DESCRIPTION
Bumped version numbers to avoid the following error while installing from instructions on MacOS. 

llava 1.2.2.post1 requires torch==2.1.2, but you have torch 2.1.0 which is incompatible. 
llava 1.2.2.post1 requires torchvision==0.16.2, but you have torchvision 0.16.0 which is incompatible.