### PR TITLE
Add Support for S^2

### DIFF
--- a/llava/model/multimodal_encoder/builder.py
+++ b/llava/model/multimodal_encoder/builder.py
@@ -1,11 +1,15 @@
 import os
-from .clip_encoder import CLIPVisionTower
+from .clip_encoder import CLIPVisionTower, CLIPVisionTowerS2
 
 
 def build_vision_tower(vision_tower_cfg, **kwargs):
     vision_tower = getattr(vision_tower_cfg, 'mm_vision_tower', getattr(vision_tower_cfg, 'vision_tower', None))
     is_absolute_path_exists = os.path.exists(vision_tower)
+    use_s2 = getattr(vision_tower_cfg, 's2', False)
     if is_absolute_path_exists or vision_tower.startswith("openai") or vision_tower.startswith("laion") or "ShareGPT4V" in vision_tower:
-        return CLIPVisionTower(vision_tower, args=vision_tower_cfg, **kwargs)
+        if use_s2:
+            return CLIPVisionTowerS2(vision_tower, args=vision_tower_cfg, **kwargs)
+        else:
+            return CLIPVisionTower(vision_tower, args=vision_tower_cfg, **kwargs)
 
     raise ValueError(f'Unknown vision tower: {vision_tower}')

--- a/llava/model/multimodal_encoder/clip_encoder.py
+++ b/llava/model/multimodal_encoder/clip_encoder.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 
 from transformers import CLIPVisionModel, CLIPImageProcessor, CLIPVisionConfig
+from s2wrapper import forward as multiscale_forward
 
 
 class CLIPVisionTower(nn.Module):
@@ -86,3 +87,56 @@ class CLIPVisionTower(nn.Module):
     @property
     def num_patches(self):
         return (self.config.image_size // self.config.patch_size) ** 2
+
+
+
+class CLIPVisionTowerS2(CLIPVisionTower):
+    def __init__(self, vision_tower, args, delay_load=False):
+        super().__init__(vision_tower, args, delay_load)
+
+        self.s2_scales = getattr(args, 's2_scales', '336,672,1008')
+        self.s2_scales = list(map(int, self.s2_scales.split(',')))
+        self.s2_scales.sort()
+        self.s2_split_size = self.s2_scales[0]
+        self.s2_image_size = self.s2_scales[-1]
+
+        # change resize/crop size in preprocessing to the largest image size in s2_scale
+        if not delay_load or getattr(args, 'unfreeze_mm_vision_tower', False):
+            self.image_processor.size['shortest_edge'] = self.s2_image_size
+            self.image_processor.crop_size['height'] = self.image_processor.crop_size['width'] = self.s2_image_size
+
+    def load_model(self, device_map=None):
+        if self.is_loaded:
+            print('{} is already loaded, `load_model` called again, skipping.'.format(self.vision_tower_name))
+            return
+
+        self.image_processor = CLIPImageProcessor.from_pretrained(self.vision_tower_name)
+        self.vision_tower = CLIPVisionModel.from_pretrained(self.vision_tower_name, device_map=device_map)
+        self.vision_tower.requires_grad_(False)
+
+        self.image_processor.size['shortest_edge'] = self.s2_image_size
+        self.image_processor.crop_size['height'] = self.image_processor.crop_size['width'] = self.s2_image_size
+
+        self.is_loaded = True
+
+    @torch.no_grad()
+    def forward_feature(self, images):
+        image_forward_outs = self.vision_tower(images.to(device=self.device, dtype=self.dtype), output_hidden_states=True)
+        image_features = self.feature_select(image_forward_outs).to(images.dtype)
+        return image_features
+
+    @torch.no_grad()
+    def forward(self, images):
+        if type(images) is list:
+            image_features = []
+            for image in images:
+                image_feature = multiscale_forward(self.forward_feature, image.unsqueeze(0), img_sizes=self.s2_scales, max_split_size=self.s2_split_size)
+                image_features.append(image_feature)
+        else:
+            image_features = multiscale_forward(self.forward_feature, images, img_sizes=self.s2_scales, max_split_size=self.s2_split_size)
+
+        return image_features
+
+    @property
+    def hidden_size(self):
+        return self.config.hidden_size * len(self.s2_scales)


### PR DESCRIPTION
## What does this PR do?

This PR integrates S<sup>2</sup> into LLaVA-NeXT. 

## What is S<sup>2</sup>?

S<sup>2</sup> is a method to extract multi-scale features from an image. For example, given an image of 336x336, S<sup>2</sup> interpolates the image to multiple scales such as 336x336, 672x672, 1008x1008, extracts features at each scale and merge the features into a multi-scale feature map. The multi-scale features contain more detailed information about an image which is beneficial for Multimodal LLMs. Meanwhile, S<sup>2</sup> ensures the number of visual token sent to LLM is the same as the regular single-scale features such that no computational overhead on LLM is incurred.

Please find more details in the S<sup>2</sup> [paper](https://arxiv.org/abs/2403.13043) and [GitHub repo](https://github.com/bfshi/scaling_on_scales).

## What does this PR contain?

There are two changes in this PR. 
- A new class of `CLIPVisionTowerS2` is defined in `llava/model/multimodal_encoder/clip_encoder.py` which augments a clip model with S<sup>2</sup>. This class is the same as the original `CLIPVisionTower` class except that it will return a multi-scale feature map instead of a single-scale feature map when `forward` is called. The multi-scale feature map has the same shape as the single-scale one, except on the channel dimension where multi-scale features have `num_scales * original_dim` dimensions (as defined in `self.hidden_size`).
- `llava/model/multimodal_encoder/builder.py` is modified so that it will build `CLIPVisionTowerS2` instead of `CLIPVisionTower` when S<sup>2</sup> is used.

## How to train LLaVA with S<sup>2</sup>?

First install `s2wrapper` through pip:
```
pip install git+https://github.com/bfshi/scaling_on_scales.git
```
This package only has one dependency of `einops`, so installing it shouldn't interfere with your environment.

Training configurations should be the same as training a regular LLaVA **without** anyres (*i.e.*, `image_aspect_ratio="pad"` and `mm_patch_merge_type="flat"`), except for two new model configs:
- `s2=True`. This turns on the usage of S<sup>2</sup>.
- `s2_scales="336,672,1008"`. This specifies the image scales S<sup>2</sup> will extract features on.