### PR TITLE
Update docstring for unpad_image

### DIFF
--- a/llava/model/llava_arch.py
+++ b/llava/model/llava_arch.py
@@ -103,7 +103,7 @@ def unpad_image(tensor, original_size):
 
     Args:
     tensor (torch.Tensor): The image tensor, assumed to be in CxHxW format.
-    original_size (tuple): The original size of the image (height, width).
+    original_size (tuple): The original size of PIL image (width, height).
 
     Returns:
     torch.Tensor: The unpadded image tensor.


### PR DESCRIPTION
The docstring had an incorrect description of original_size. the original_size is taken directly for the PIL image (image.size) and it is of shape (width, height). This is reflected in the code, but not in the docstring.