### PR TITLE
Update clip_encoder.py for s^2

### DIFF
--- a/llava/model/multimodal_encoder/clip_encoder.py
+++ b/llava/model/multimodal_encoder/clip_encoder.py
@@ -91,14 +91,13 @@ class CLIPVisionTower(nn.Module):
 
 class CLIPVisionTowerS2(CLIPVisionTower):
     def __init__(self, vision_tower, args, delay_load=False):
-        super().__init__(vision_tower, args, delay_load)
-
         self.s2_scales = getattr(args, 's2_scales', '336,672,1008')
         self.s2_scales = list(map(int, self.s2_scales.split(',')))
         self.s2_scales.sort()
         self.s2_split_size = self.s2_scales[0]
         self.s2_image_size = self.s2_scales[-1]
-
+        super().__init__(vision_tower, args, delay_load)
+        
         try:
             from s2wrapper import forward as multiscale_forward
         except ImportError:


### PR DESCRIPTION
Calling `super().__init__(vision_tower, args, delay_load)` will reult in `ValueError` as the parent class `CLIPVisionTower` would call `load_model` method and attemp to access `s2_scales` while the attribute is still to be defined yet.

By calling `load_model` after `s2_scales` is defined in `__init__` can resolve this issue.