### PR TITLE
add ocr vqa images

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Please download the annotation of the final mixture our instruction tuning data 
 
 - COCO: [train2017](http://images.cocodataset.org/zips/train2017.zip)
 - GQA: [images](https://downloads.cs.stanford.edu/nlp/data/gqa/images.zip)
-- OCR-VQA: [download script](https://drive.google.com/drive/folders/1_GYPY5UkUy7HIcR0zq3ZCFgeZN7BAfm_?usp=sharing), **we save all files as `.jpg`**
+- OCR-VQA: [images](https://huggingface.co/datasets/weizhiwang/llava_v15_instruction_images/resolve/main/ocr_vqa_images_llava_v15.zip?download=true)
 - TextVQA: [train_val_images](https://dl.fbaipublicfiles.com/textvqa/images/train_val_images.zip)
 - VisualGenome: [part1](https://cs.stanford.edu/people/rak248/VG_100K_2/images.zip), [part2](https://cs.stanford.edu/people/rak248/VG_100K_2/images2.zip)
 


### PR DESCRIPTION
Most of downloading urls of images in ocr_vqa dataset are no longer available. Everyone has to rerun the downloading script to get a small portion of ocr_vqa images in the LLaVA-v1.5-665k instruction dataset. I zip all images from original release into a zip file. Everyone can easily download it and unzip to their path of `./ocr_vqa/images`