### PR TITLE
automatically added to python module search path

### DIFF
--- a/llava/train/train_mem.py
+++ b/llava/train/train_mem.py
@@ -1,3 +1,12 @@
+import sys
+import os
+
+# Ensure the project root directory is 
+# automatically added to Python module search path
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if root_dir not in sys.path:
+    sys.path.insert(0, root_dir)
+    
 from llava.train.train import train
 
 if __name__ == "__main__":


### PR DESCRIPTION
When running the script scripts/pretrain.sh directly, a ModuleNotFoundError: No module named 'llava' may occur. Implement automatic configuration of the Python search path to include the necessary directory.
related issue:
https://github.com/haotian-liu/LLaVA/issues/1571