### PR TITLE
Pinning the peft library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 dependencies = [
     "torch==2.1.2", "torchvision==0.16.2",
     "transformers==4.37.2", "tokenizers==0.15.1", "sentencepiece==0.1.99", "shortuuid",
-    "accelerate==0.21.0", "peft", "bitsandbytes",
+    "accelerate==0.21.0", "peft==0.13.2", "bitsandbytes",
     "pydantic", "markdown2[all]", "numpy", "scikit-learn==1.2.2",
     "gradio==4.16.0", "gradio_client==0.8.1",
     "requests", "httpx==0.24.0", "uvicorn", "fastapi",


### PR DESCRIPTION
The 0.14.0 release on 12/6 of PEFT created some conflicts with transformers. Pinning to last release of 0.13.2 to fix things.