### PR TITLE
fix: replace hardcoded .cuda() with dynamic device inference

### DIFF
--- a/llava/eval/run_llava.py
+++ b/llava/eval/run_llava.py
@@ -108,7 +108,7 @@ def eval_model(args):
     input_ids = (
         tokenizer_image_token(prompt, tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt")
         .unsqueeze(0)
-        .cuda()
+        .to(model.device)
     )
 
     with torch.inference_mode():


### PR DESCRIPTION
## Bug

In `llava/eval/run_llava.py`, `input_ids` is placed on device via a hardcoded `.cuda()` call (line 111). This breaks inference on non-CUDA devices (MPS, CPU) and can cause device mismatch errors in multi-GPU setups.

Notably, `images_tensor` on the preceding line already correctly uses `.to(model.device, ...)`, making the hardcoded `.cuda()` on `input_ids` inconsistent.

## Fix

Replaced `.cuda()` with `.to(model.device)` so `input_ids` is placed on the same device as the model, matching the pattern already used for `images_tensor`.