### PR TITLE
fix: return attention_mask when padding is applied regardless of input mask

### DIFF
--- a/llava/model/llava_arch.py
+++ b/llava/model/llava_arch.py
@@ -313,10 +313,16 @@ class LlavaMetaForCausalLM(ABC):
         else:
             new_labels = new_labels_padded
 
-        if _attention_mask is None:
-            attention_mask = None
+        if attention_mask.all():
+            # No padding was applied, respect original attention_mask presence
+            if _attention_mask is None:
+                attention_mask = None
+            else:
+                attention_mask = attention_mask.to(dtype=_attention_mask.dtype)
         else:
-            attention_mask = attention_mask.to(dtype=_attention_mask.dtype)
+            # Padding was applied, always return the new attention_mask
+            if _attention_mask is not None:
+                attention_mask = attention_mask.to(dtype=_attention_mask.dtype)
 
         if _position_ids is None:
             position_ids = None


### PR DESCRIPTION
## Problem

In `prepare_inputs_labels_for_multimodal()`, when batch inputs have different lengths and padding is applied, the recomputed `attention_mask` is discarded if the original `_attention_mask` was `None`. This causes the model to attend to padding tokens during batch inference.

## Fix

Check whether padding was actually applied (i.e. `attention_mask` contains any `False` values). If so, always return the padded `attention_mask` so the model correctly ignores padding tokens.

When no padding is applied, preserve the original behavior of respecting `_attention_mask is None`.

Fixes #1720